### PR TITLE
Fix type cast error in strict typed phtml

### DIFF
--- a/view/frontend/templates/head/fb_open_graph.phtml
+++ b/view/frontend/templates/head/fb_open_graph.phtml
@@ -32,7 +32,7 @@ $ogData = $block->getOpenGraphData()
 <?php endif; ?>
 
 <?php foreach ($ogData as $key => $value): ?>
-    <?php if (isset($key)): ?>
-        <meta property="og:<?php echo $block->escapeQuote($key); ?>" content="<?php echo $block->escapeQuote($value); ?>">
+    <?php if (isset($key, $value)): ?>
+        <meta property="og:<?php echo $block->escapeQuote((string)$key); ?>" content="<?php echo $block->escapeQuote((string)$value); ?>">
     <?php endif; ?>
 <?php endforeach; ?>


### PR DESCRIPTION
If the value is empty or not a `string`  the ` $block->escapeQuote`  fails  in `2.4.x`  branch of Magento because get more strict typing here 